### PR TITLE
Adding collective.setdefaulteditor as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(name='collective.upgrade',
           'setuptools',
           # -*- Extra requirements: -*-
           'zodbupdate',
+          'collective.setdefaulteditor',
           'experimental.broken',
           'Products.GenericSetup',
           'Products.CMFCore',


### PR DESCRIPTION
it is used in steps.zcml: .steps.setDefaultEditor
