### PR TITLE
Ensure the the reconciling import steps are only run if the PAS plugins have been setup.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 0.4 - unreleased
 ----------------
 
-- No changes
+- Ensure the the reconciling import steps are only run if the PAS plugins
+  have been set up.
+  [href]
 
 
 0.3 - 2014-01-30

--- a/src/collective/upgrade/pas.py
+++ b/src/collective/upgrade/pas.py
@@ -299,21 +299,44 @@ class DataFile(object):
         self.file = file_
 
 
+def is_reconcileable(context):
+    try:
+        site = context.getSite()
+        acl_users = getToolByName(site, 'acl_users')
+        acl_users._getOb('plugins')
+    except AttributeError:
+        return False
+    else:
+        return True
+
+
 def reconcileUsersExport(context):
+    if not is_reconcileable(context):
+        return
+
     reconciler = ExportReconciler(context, 'user')
     reconciler.export_rows()
 
 
 def reconcileGroupsExport(context):
+    if not is_reconcileable(context):
+        return
+
     reconciler = ExportReconciler(context, 'group')
     reconciler.export_rows()
 
 
 def reconcileUsersImport(context):
+    if not is_reconcileable(context):
+        return
+
     reconciler = ImportReconciler(context, 'user')
     reconciler.import_rows()
 
 
 def reconcileGroupsImport(context):
+    if not is_reconcileable(context):
+        return
+
     reconciler = ImportReconciler(context, 'group')
     reconciler.import_rows()


### PR DESCRIPTION
I tried finding an import step to depend on, but it looks like there isn't one for the plugin registry.
