### PR TITLE
Complete portal setup before migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,12 @@ Changelog
   using plone.app.registry.
   [rpatterson]
 
+- Added argument to define Zope user id to use.
+  [gbastien]
+
+- Complete portal setup : portal_skins, portal_languages, BrowserLayer.
+  [gbastien]
+
 
 1.1 - 2014-05-08
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,8 @@ Use the ``--help`` option for more details::
                             When upgrading a portal using plone.app.linkintegrity,
                             disable it during the upgrade.
       -u, --username
-                            Specify username to use during the upgrade.
+                            Specify username to use during the upgrade (if not
+                            provided, a special user will run the upgrade).
 
     upgrades:
       -U, --skip-portal-upgrade

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,9 @@ Use the ``--help`` option for more details::
       -d, --disable-link-integrity
                             When upgrading a portal using plone.app.linkintegrity,
                             disable it during the upgrade.
-    
+      -u, --username
+                            Specify username to use during the upgrade.
+
     upgrades:
       -U, --skip-portal-upgrade
                             Skip running the upgrade steps for the core Plone

--- a/src/collective/upgrade/portals.py
+++ b/src/collective/upgrade/portals.py
@@ -16,7 +16,6 @@ class PortalsUpgrader(utils.Upgrader):
             self.log('Upgrading all portals')
 
         for upgrader in upgraders:
-            # Get Plone site object from Zope application server root
             upgrader.upgrade(**kw)
 
     def walkUpgraders(self, context):

--- a/src/collective/upgrade/portals.py
+++ b/src/collective/upgrade/portals.py
@@ -1,3 +1,4 @@
+from zope.component.hooks import setSite
 from collective.upgrade import utils
 
 
@@ -16,6 +17,12 @@ class PortalsUpgrader(utils.Upgrader):
             self.log('Upgrading all portals')
 
         for upgrader in upgraders:
+            setSite(upgrader.context)
+            # initialize portal_skins
+            upgrader.context.setupCurrentSkin(self.context.REQUEST)
+            # setup language
+            upgrader.context.portal_languages(upgrader.context, self.context.REQUEST)
+            # Get Plone site object from Zope application server root
             upgrader.upgrade(**kw)
 
     def walkUpgraders(self, context):

--- a/src/collective/upgrade/portals.py
+++ b/src/collective/upgrade/portals.py
@@ -1,4 +1,3 @@
-from zope.component.hooks import setSite
 from collective.upgrade import utils
 
 
@@ -17,11 +16,6 @@ class PortalsUpgrader(utils.Upgrader):
             self.log('Upgrading all portals')
 
         for upgrader in upgraders:
-            setSite(upgrader.context)
-            # initialize portal_skins
-            upgrader.context.setupCurrentSkin(self.context.REQUEST)
-            # setup language
-            upgrader.context.portal_languages(upgrader.context, self.context.REQUEST)
             # Get Plone site object from Zope application server root
             upgrader.upgrade(**kw)
 

--- a/src/collective/upgrade/run.py
+++ b/src/collective/upgrade/run.py
@@ -25,7 +25,7 @@ parser.add_argument(
     'disable it during the upgrade.')
 parser.add_argument(
     "-u", "--username", help='Specify username to use during the upgrade '
-    '(if not provided, a special user will run the upgrade)')
+    '(if not provided, a special user will run the upgrade).')
 
 group = parser.add_argument_group('upgrades')
 group.add_argument(

--- a/src/collective/upgrade/run.py
+++ b/src/collective/upgrade/run.py
@@ -23,6 +23,8 @@ parser.add_argument(
     "-d", "--disable-link-integrity", action="store_true",
     help='When upgrading a portal using plone.app.linkintegrity, '
     'disable it during the upgrade.')
+parser.add_argument(
+    "-u", "--username", help='Specify username to use during the upgrade.')
 
 group = parser.add_argument_group('upgrades')
 group.add_argument(
@@ -91,10 +93,19 @@ def main(app=None, args=None):
     if args.disable_link_integrity:
         kw['enable_link_integrity_checks'] = False
 
-    from AccessControl import SpecialUsers
+    # setup user and REQUEST
     from AccessControl.SecurityManagement import newSecurityManager
-    newSecurityManager(None, SpecialUsers.system)
     from Testing.makerequest import makerequest
+    if args.username:
+        acl_users = app.acl_users
+        user = acl_users.getUser(args.username)
+        if user:
+            user = user.__of__(acl_users)
+    else:
+        from AccessControl import SpecialUsers
+        user = SpecialUsers.system
+
+    newSecurityManager(None, user)
     app = makerequest(app)
 
     runner = app.restrictedTraverse('@@collective.upgrade.form')

--- a/src/collective/upgrade/run.py
+++ b/src/collective/upgrade/run.py
@@ -24,7 +24,8 @@ parser.add_argument(
     help='When upgrading a portal using plone.app.linkintegrity, '
     'disable it during the upgrade.')
 parser.add_argument(
-    "-u", "--username", help='Specify username to use during the upgrade.')
+    "-u", "--username", help='Specify username to use during the upgrade '
+    '(if not provided, a special user will run the upgrade)')
 
 group = parser.add_argument_group('upgrades')
 group.add_argument(

--- a/src/collective/upgrade/utils.py
+++ b/src/collective/upgrade/utils.py
@@ -5,9 +5,7 @@ import transaction
 from zope import globalrequest
 from zope import interface
 from zope.component import hooks
-from zope.event import notify
 from zope.publisher import browser
-from zope.traversing.interfaces import BeforeTraverseEvent
 
 import zodbupdate.main
 

--- a/src/collective/upgrade/utils.py
+++ b/src/collective/upgrade/utils.py
@@ -1,12 +1,13 @@
-import logging
 import contextlib
-
+import logging
 import transaction
 
+from zope import globalrequest
 from zope import interface
 from zope.component import hooks
+from zope.event import notify
 from zope.publisher import browser
-from zope import globalrequest
+from zope.traversing.interfaces import BeforeTraverseEvent
 
 import zodbupdate.main
 


### PR DESCRIPTION
Hi @rpatterson 

this PR brings support for migrations using portal_skins or resources, different language than 'en' and when using BrowserLayer.

I added also the possibility to use a Zope user (admin) as user during migration.

Could you please review and merge?

Thank you!

Gauthier