### PR TITLE
portal_languages is no longer a persistent too

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 1.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Bugfix: portal_languages is no longer a persistent tool.
+  See: https://docs.plone.org/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.html#portal-languages-is-now-a-utility
+  [bsuttor]
 
 
 1.3 (2018-04-18)

--- a/src/collective/upgrade/upgrader.py
+++ b/src/collective/upgrade/upgrader.py
@@ -22,8 +22,9 @@ class PortalUpgrader(utils.Upgrader):
         setRequest(self.context.REQUEST)
         # initialize portal_skins
         self.context.setupCurrentSkin(self.context.REQUEST)
-        # setup language
-        self.context.portal_languages(self.context, self.context.REQUEST)
+        # setup language for plone 4: see https://docs.plone.org/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.html#portal-languages-is-now-a-utility  # noqa
+        if getattr(self.context, 'portal_languages', None):
+            self.context.portal_languages(self.context, self.context.REQUEST)
         self.setup = getToolByName(self.context, 'portal_setup')
         self.log('Upgrading {0}'.format(self.context))
         # setup BrowserLayer, see: https://dev.plone.org/ticket/11673


### PR DESCRIPTION
It's now provided by plone.i18n using registerToolInterface. So no more needed to set it on upgarde.
see:
- https://docs.plone.org/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.html#portal-languages-is-now-a-utility
- https://community.plone.org/t/portal-languages-in-plone-5-gone/742